### PR TITLE
没有inbound访问权限时，返回CURLE_RECV_ERROR (56)网络提示

### DIFF
--- a/pkg/sidecar/providers/pipy/repo/codebase/modules/inbound-main.js
+++ b/pkg/sidecar/providers/pipy/repo/codebase/modules/inbound-main.js
@@ -98,7 +98,7 @@
 
   (
     $=>$.replaceStreamStart(
-      new StreamEnd()
+      new StreamEnd('ConnectionReset')
     )
   )
 )


### PR DESCRIPTION
没有inbound访问权限时，返回CURLE_RECV_ERROR (56)网络提示.
如下2个 e2e测试通过：
E2E_FLAGS='-kindClusterName=osm -timeout 900s -ginkgo.focus="Permissive mode HTTP test with a Kubernetes Service for the Source"' make test-e2e
E2E_FLAGS='-kindClusterName=osm -timeout 900s -ginkgo.focus="Permissive mode HTTP test without a Kubernetes Service for the Source"' make test-e2e