### PR TITLE
pipy sidecar 访问 127.0.0.1时，使用源地址 127.0.0.6

### DIFF
--- a/pkg/sidecar/providers/pipy/repo/codebase/connect-tcp.js
+++ b/pkg/sidecar/providers/pipy/repo/codebase/connect-tcp.js
@@ -42,7 +42,14 @@ pipy({
     _metrics.sendBytesTotalCounter.increase(data.size)
   )
 )
-.connect(() => __target)
+.branch(
+  () => __target.startsWith('127.0.0.1:'), (
+    $=>$.connect(() => __target, { bind: '127.0.0.6' })
+  ),
+  (
+    $=>$.connect(() => __target)
+  )
+)
 .handleData(
   data => (
     _metrics.receiveBytesTotalCounter.increase(data.size)


### PR DESCRIPTION
pipy sidecar 访问 127.0.0.1时，使用源地址 127.0.0.6