### PR TITLE
增加RemoteLoggingLevel配置项

### DIFF
--- a/pkg/sidecar/providers/pipy/repo/codebase/logging.js
+++ b/pkg/sidecar/providers/pipy/repo/codebase/logging.js
@@ -1,5 +1,6 @@
 (
   (
+    config = pipy.solve('config.js'),
     {
       namespace,
       kind,
@@ -55,10 +56,14 @@
           sampled = false,
         ) => (
           msg?.head?.headers && (
-            (isOutbound || !msg.head.headers['x-b3-traceid']) && (
-              initTracingHeaders(msg.head.headers)
-            ),
-            sampled = (!tracingLimitedID || toInt63(msg.head.headers['x-b3-traceid']) < tracingLimitedID)
+            (config?.Spec?.RemoteLoggingLevel > 0) ? (
+              ((config.Spec.RemoteLoggingLevel === 2 && isOutbound) || !msg.head.headers['x-b3-traceid']) && (
+                initTracingHeaders(msg.head.headers)
+              ),
+              sampled = (!tracingLimitedID || toInt63(msg.head.headers['x-b3-traceid']) < tracingLimitedID)
+            ) : (
+              sampled = true
+            )
           ),
           sampled ? (
             {
@@ -78,12 +83,12 @@
                 name: os.env.POD_NAME || os.env.HOSTNAME || 'localhost',
               },
               trace: {
-                id: msg.head.headers?.['x-b3-traceid'] || '',
-                span: msg.head.headers?.['x-b3-spanid'] || '',
-                parent: msg.head.headers?.['x-b3-parentspanid'] || '',
+                id: msg.head?.headers?.['x-b3-traceid'] || '',
+                span: msg.head?.headers?.['x-b3-spanid'] || '',
+                parent: msg.head?.headers?.['x-b3-parentspanid'] || '',
                 sampled: '1',
               },
-              req: Object.assign({ reqSize: msg.body.size, body: msg.body.toString('base64') }, msg.head)
+              req: Object.assign({ reqSize: msg.body?.size, body: msg.body?.toString?.('base64') }, msg.head)
             }
           ) : null
         )
@@ -94,8 +99,8 @@
           name: service || 'anonymous', target: target, ingressMode: isIngress, egressMode: isEgress
         },
         loggingData.res = Object.assign({}, msg.head),
-        loggingData.res['resSize'] = msg.body.size,
-        loggingData.res['body'] = msg.body.toString('base64'),
+        loggingData.res['resSize'] = msg.body?.size,
+        loggingData.res['body'] = msg.body?.toString?.('base64'),
         loggingData['resTime'] = Date.now(),
         loggingData['endTime'] = Date.now(),
         loggingData['type'] = type,


### PR DESCRIPTION
增加RemoteLoggingLevel配置项
0: osm-edge 不添加 x-b3, 使用应用本身的 x-b3,
1: 如果 inbound/outbound 的 http 里面没有 x-b3 则添加
2: 如果 inbound 的 http 里面没有 x-b3-trace 则添加
   outbound 强制添加x-b3